### PR TITLE
Remove verbose if statements 

### DIFF
--- a/www/coffee/app.coffee
+++ b/www/coffee/app.coffee
@@ -18,8 +18,8 @@ angular.module("starter", [
   ])
   .run(($ionicPlatform) ->
     $ionicPlatform.ready ->
-      cordova.plugins.Keyboard.hideKeyboardAccessoryBar true  if window.cordova and window.cordova.plugins.Keyboard
-      StatusBar.styleDefault()  if window.StatusBar
+      window.cordova?.plugins.Keyboard?.hideKeyboardAccessoryBar()
+      window.StatusBar?.styleDefault()
   )
   .config ($stateProvider, $urlRouterProvider) ->
     $stateProvider.state("tab",


### PR DESCRIPTION
the `.run` part of `app.coffee` was using a very verbose syntax for feature detection on the status bar and keyboard plugin. 

http://coffeescript.org/ and ctrl+f for existential operator
